### PR TITLE
404 page

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,30 @@
+import NavLayout from "@/components/NavLayout";
+import { Button, Center, Flex, Text } from "@chakra-ui/react";
+import Link from "next/link";
+
+export default function NotFoundPage() {
+  return (
+    <NavLayout>
+      <Center>
+        <Flex
+          direction="column"
+          pt={20}
+          gap={5}
+          m="auto"
+          mb={20}
+          textAlign="center"
+        >
+          <Text fontWeight="bold">
+            죄송합니다. 페이지를 사용할 수 없습니다.
+          </Text>
+          <Text>클릭하신 링크가 잘못되었거나 페이지가 삭제되었습니다.</Text>
+          <Link href="/feed">
+            <Button color="primary" bg="gray.300" fontWeight="bold">
+              Arterest로 돌아가기
+            </Button>
+          </Link>
+        </Flex>
+      </Center>
+    </NavLayout>
+  );
+}


### PR DESCRIPTION
## 주요 기능
- 404 페이지 추가

## 고려할 사항
- 현재 `/*`로 진입하면 무조건 `/[id]`에 걸리기 때문에 404페이지는 `/*/잘못된경로` 혹은 `/404` 진입 시에만 볼 수 있음
- `/없는ID`인 경우에는 별도로 처리 필요

## 관련 이슈
Close #19 